### PR TITLE
Suppress useless params which cause to high speed picture move

### DIFF
--- a/src/components/Cropper.js
+++ b/src/components/Cropper.js
@@ -549,7 +549,6 @@ class Cropper extends Component {
         <Draggable
           onStop={this.onDragStop}
           bounds={bounds}
-          scale={currentZoom}
           position={{
             x: holePositionX - picturePositionX,
             y: holePositionY - picturePositionY,


### PR DESCRIPTION
- [ ] Too high speed move on big picture due to bad scale param